### PR TITLE
fix: Bump the docker image to a fixed one.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN cp -a docker/settings.php docker/services.yml html/sites/default
 ################################################################################
 
 # Generate the image.
-FROM public.ecr.aws/unocha/php-k8s:8.0-stable
+FROM public.ecr.aws/unocha/php-k8s:8.0.28-r0-202304-01
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
This image tag includes fixes that allow stage-file-proxy to fetch images when on a non-production environment.

Refs: OPS-9251