### PR TITLE
fix: return response objects for failed pdfs

### DIFF
--- a/html/modules/custom/gms_pdflink/src/Controller/PrintSectionController.php
+++ b/html/modules/custom/gms_pdflink/src/Controller/PrintSectionController.php
@@ -10,7 +10,6 @@ use Drupal\Core\Render\Markup;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Drupal\Component\Utility\Html;
 use Symfony\Component\HttpFoundation\Response;
@@ -127,7 +126,7 @@ class PrintSectionController extends ControllerBase {
       $pdf     = ocha_snap($url, $params);
       if (empty($pdf)) {
         $this->messenger()->addMessage($this->t('Failed to generate a PDF file.'), 'error');
-        $response = new RedirectResponse($url, 301);
+        $response = new Response($this->t('Failed to generate a PDF file.'), 503);
         $response->send();
       }
       else {
@@ -143,9 +142,8 @@ class PrintSectionController extends ControllerBase {
       }
     }
     else {
-      global $base_url;
       $this->messenger()->addMessage($this->t('Access denied.'), 'error');
-      $response = new RedirectResponse($base_url, 301);
+      $response = new Response($this->t('Access denied.'), 403);
       $response->send();
     }
 
@@ -213,9 +211,8 @@ class PrintSectionController extends ControllerBase {
       die;
     }
     else {
-      global $base_url;
       $this->messenger()->addMessage($this->t('Access denied.'), 'error');
-      $response = new RedirectResponse($base_url, 301);
+      $response = new Response($this->t('Access denied.'), 403);
       $response->send();
     }
   }

--- a/html/modules/custom/gms_pdflink/src/Controller/ViewPdfController.php
+++ b/html/modules/custom/gms_pdflink/src/Controller/ViewPdfController.php
@@ -10,7 +10,6 @@ use Drupal\Core\Url;
 use Drupal\Component\Utility\Html;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -122,7 +121,7 @@ class ViewPdfController extends ControllerBase {
       $pdf = ocha_snap($url, $params);
       if (empty($pdf)) {
         $this->messenger()->addMessage($this->t('Failed to generate a PDF file.'), 'error');
-        $response = new RedirectResponse($url, 301);
+        $response = new Response($this->t('Failed to generate a PDF file.'), 503);
         $response->send();
       }
       else {
@@ -138,9 +137,8 @@ class ViewPdfController extends ControllerBase {
       }
     }
     else {
-      global $base_url;
       $this->messenger()->addMessage($this->t('Access denied.'), 'error');
-      $response = new RedirectResponse($base_url, 301);
+      $response = new Response($this->t('Access denied.'), 403);
       $response->send();
     }
   }


### PR DESCRIPTION
Refs: OPS-9238

We're getting a steady stream of errors when pdfs can't be made https://elk.aws.ahconu.org/goto/afba81a0-f8b8-11ed-b5c3-e985604325fd

```
Symfony\Component\HttpKernel\Exception\ControllerDoesNotReturnResponseException: The controller must return a "Symfony\Component\HttpFoundation\Response" object but it returned null. Did you forget to add a return statement somewhere in your controller? in () (line 98 of /srv/www/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php).
```

Haven't tested this properly locally as I have an issue with snap, but I think it might help. The http response codes are suggestions.