### PR TITLE
fix: Disable onomasticon on basic_html, so Glossary descriptions do not cause infinite loops when they contain a Glossary term.

### DIFF
--- a/config/filter.format.basic_html.yml
+++ b/config/filter.format.basic_html.yml
@@ -55,10 +55,11 @@ filters:
   filter_onomasticon:
     id: filter_onomasticon
     provider: onomasticon
-    status: true
+    status: false
     weight: 0
     settings:
       onomasticon_vocabulary: glossary
+      onomasticon_definition_field: description
       onomasticon_tag: dfn
       onomasticon_disabled: 'abbr audio button cite code dfn form meta object pre style script video'
       onomasticon_implement: attr_title


### PR DESCRIPTION
See https://www.drupal.org/project/onomasticon/issues/3376245

Refs: OPS-9539