### PR TITLE
fix: This is the only controller we invoke, so make it return a response object.

### DIFF
--- a/docker/99-elastic-apm-custom.ini
+++ b/docker/99-elastic-apm-custom.ini
@@ -1,0 +1,19 @@
+; This file contains the various settings for the Elastic APM PHP agent. For
+; further details refers to the following URL:
+; https://www.elastic.co/guide/en/apm/agent/php/current/configuration-reference.html
+;
+
+[elastic]
+elastic_apm.enabled = ${PHP_ELASTIC_APM_ENABLED}
+;elastic_apm.api_key = "REPLACE_WITH_API_KEY"
+elastic_apm.environment = "${PHP_ELASTIC_APM_ENVIRONMENT}"
+elastic_apm.log_level = "INFO"
+elastic_apm.log_level_stderr = "INFO"
+elastic_apm.secret_token = "${PHP_ELASTIC_APM_TOKEN}"
+;elastic_apm.server_timeout = "30s"
+elastic_apm.server_url = "${PHP_ELASTIC_APM_SERVER}"
+elastic_apm.service_name = "${PHP_ELASTIC_APM_SERVICE}"
+elastic_apm.service_version = ${GIT_SHA}
+;elastic_apm.transaction_max_spans = 500
+;elastic_apm.transaction_sample_rate = 1.0
+;elastic_apm.verify_server_cert = true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,3 +61,9 @@ COPY --from=builder /srv/www/composer.patches.json /srv/www/composer.patches.jso
 COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
 COPY --from=builder /srv/www/symfony.lock /srv/www/symfony.lock
 COPY --from=builder /srv/www/PATCHES /srv/www/PATCHES
+COPY --from=builder /srv/www/docker/99-elastic-apm-custom.ini /tmp/99-elastic-apm-custom.ini
+
+RUN  curl -L -o /tmp/apm-agent-php_all.apk https://github.com/elastic/apm-agent-php/releases/download/v1.10.0/apm-agent-php_1.10.0_all.apk && \
+     apk add --allow-untrusted /tmp/apm-agent-php_all.apk && \
+     rm -f /tmp/apm-agent-php_all.apk && \
+     mv -f /tmp/99-elastic-apm-custom.ini /etc/php82/conf.d/99-elastic-apm-custom.ini

--- a/html/modules/custom/gms_pdflink/src/Controller/PrintSectionController.php
+++ b/html/modules/custom/gms_pdflink/src/Controller/PrintSectionController.php
@@ -148,6 +148,7 @@ class PrintSectionController extends ControllerBase {
       $response = new RedirectResponse($base_url, 301);
       $response->send();
     }
+    return $response;
 
   }
 
@@ -208,9 +209,16 @@ class PrintSectionController extends ControllerBase {
                   </style>
                 </head>
                 <body>' . $content . '</body>
-             </html>';
-      echo $html;
-      die;
+                </html>';
+
+      // This could *possibly* be an HtmlResponse but things seem to work as-is.
+      $response = new Response();
+      $response->headers->set('Pragma', 'no-cache');
+      $response->headers->set('Content-type', 'text/html; charset=utf-8');
+      $response->headers->set('Cache-control', 'private');
+      $response->headers->set('Content-length', strlen($html));
+      $response->setContent($html);
+      $response->send();
     }
     else {
       global $base_url;
@@ -218,6 +226,7 @@ class PrintSectionController extends ControllerBase {
       $response = new RedirectResponse($base_url, 301);
       $response->send();
     }
+    return $response;
   }
 
 }

--- a/html/modules/custom/gms_pdflink/src/Controller/ViewPdfController.php
+++ b/html/modules/custom/gms_pdflink/src/Controller/ViewPdfController.php
@@ -143,6 +143,7 @@ class ViewPdfController extends ControllerBase {
       $response = new RedirectResponse($base_url, 301);
       $response->send();
     }
+    return $response;
   }
 
 }


### PR DESCRIPTION
Even if nothing else happens to it, at least this way we do not trigger a spurious PHP error about needing to return a response. That will *hopefully* sort the last of the on-going GMS errors. Until the site is updated to Drupal 10.

Refs: OPS-9090