### PR TITLE
chore: Drop in a custom rate limiting config template to handle PDF print links.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=builder /srv/www/composer.lock /srv/www/composer.lock
 COPY --from=builder /srv/www/symfony.lock /srv/www/symfony.lock
 COPY --from=builder /srv/www/PATCHES /srv/www/PATCHES
 COPY --from=builder /srv/www/docker/99-elastic-apm-custom.ini /tmp/99-elastic-apm-custom.ini
+COPY --from=builder /srv/www/docker/etc/nginx/ratelimit.conf.template /etc/nginx/ratelimit.conf.template
 
 RUN  curl -L -o /tmp/apm-agent-php_all.apk https://github.com/elastic/apm-agent-php/releases/download/v1.10.0/apm-agent-php_1.10.0_all.apk && \
      apk add --allow-untrusted /tmp/apm-agent-php_all.apk && \

--- a/docker/etc/nginx/ratelimit.conf.template
+++ b/docker/etc/nginx/ratelimit.conf.template
@@ -1,0 +1,41 @@
+## Apply settings from the environment at boot time via envsubst.
+
+## A rate limit request returns status 429.
+limit_req_status 429;
+
+## Determine if this is a bot request via the user-agent string.
+map $http_user_agent $isbot_ua {
+        default                0;
+        ~*pingdom              0;
+        ~*(bot|crawler|spider) 1;
+        ""                     1;
+        "-"                    1;
+}
+
+## Set a limit zone based on the bot status.
+map $isbot_ua $limit_bot {
+        0       "";
+        1       $binary_remote_addr;
+}
+
+## Apply the rate limits.
+limit_req_zone $limit_bot zone=bots:10m rate=${NGINX_LIMIT_BOTS};
+limit_req_zone $binary_remote_addr zone=humans:10m rate=${NGINX_LIMIT_HUMANS};
+
+## Apply the burst limits.
+limit_req zone=bots burst=${NGINX_BURST_BOTS};
+limit_req zone=humans burst=${NGINX_BURST_HUMANS};
+
+## Define a map of URL patters that are considered expensive and
+## should be limited very hard.
+## See https://humanitarian.atlassian.net/browse/OPS-10013
+map $request_uri $binary_remote_addr_map {
+        default                 "";
+        ~*/en/page/print/pdf    $binary_remote_addr;
+        ~*/en/section/print/pdf $binary_remote_addr;
+}
+
+## Define custom zone for expensive requests for GMS and allow 1 only
+## one request per minute and no bursts or delayed response.
+limit_req_zone $binary_remote_addr_map zone=pdf:10m rate=1r/m;
+limit_req zone=pdf nodelay;


### PR DESCRIPTION
This hard-limits calls to the snap service to 1 per server per minute. That should discourage pen testers and bots, which allowing normal users to download a bunch of PDFs by clicking and waiting, given their requests are spread across three servers on production.

Refs: OPS-10013