### PR TITLE
fix: Add a *current* looking drupal-scaffold config section.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -253,16 +253,21 @@
             "drush/Commands/{$name}": ["type:drupal-drush"]
         },
         "drupal-scaffold": {
-            "initial": {
-                "sites/default/default.services.yml": "sites/default/services.yml",
-                "sites/default/default.settings.php": "sites/default/settings.php",
-                ".editorconfig": "../.editorconfig",
-                ".gitattributes": "../.gitattributes"
+            "file-mapping": {
+                "[web-root]/sites/default/services.yml": {
+                    "mode": "replace",
+                    "path": "html/core/assets/scaffold/files/default.services.yml",
+                    "overwrite": false
+                },
+                "[web-root]/sites/default/settings.php": {
+                    "mode": "replace",
+                    "path": "html/core/assets/scaffold/files/default.settings.php",
+                    "overwrite": false
+                }
             },
             "locations": {
-              "web-root": "html/"
-            },
-            "omit-defaults": false
+                "web-root": "html/"
+            }
         },
         "merge-plugin": {
             "include": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5250a41eb6992381d06414827a19cee",
+    "content-hash": "74469719733610d9de5375877732ae35",
     "packages": [
         {
             "name": "arthurkirkosa/guzzle-description-loader",
@@ -4573,6 +4573,10 @@
                 {
                     "name": "dawehner",
                     "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "dww",
+                    "homepage": "https://www.drupal.org/user/46549"
                 },
                 {
                     "name": "geek-merlin",


### PR DESCRIPTION
The idea is that this causes html/sites/default to be created, as it will copy default files there.

Refs: OPS-10074