### PR TITLE
Deploy 21-11-2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [9.7.8](https://github.com/UN-OCHA/gms-site/compare/v9.7.7...v9.7.8) (2024-11-21)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* packages. ([e48001](https://github.com/UN-OCHA/gms-site/commit/e4800176ad7b9153544be294b7e5567489f4b1fd))
+
 ## [9.7.7](https://github.com/UN-OCHA/gms-site/compare/v9.7.6...v9.7.7) (2024-11-18)
 
 ### Chores

--- a/composer.json
+++ b/composer.json
@@ -310,5 +310,5 @@
             "@git-hooks"
         ]
     },
-    "version": "9.7.7"
+    "version": "9.7.8"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bee48c811cb7b31d4d192a2397b8e73",
+    "content-hash": "df88f3bf5aefe129b15efe675d9e91d7",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [9.7.8](https://github.com/UN-OCHA/gms-site/compare/v9.7.7...v9.7.8) (2024-11-21)

### Chores

* Update all outdated drupal/* unocha/* drush/* packages. ([e48001](https://github.com/UN-OCHA/gms-site/commit/e4800176ad7b9153544be294b7e5567489f4b1fd))

## Composer changes

| Production Changes            | From    | To      | Compare                                                                         |
|-------------------------------|---------|---------|---------------------------------------------------------------------------------|
| aws/aws-sdk-php               | 3.326.0 | 3.328.3 | [...](https://github.com/aws/aws-sdk-php/compare/3.326.0...3.328.3)             |
| drupal/core                   | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core/compare/10.3.8...10.3.9)                   |
| drupal/core-composer-scaffold | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core-composer-scaffold/compare/10.3.8...10.3.9) |
| drupal/core-project-message   | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core-project-message/compare/10.3.8...10.3.9)   |
| drupal/core-recommended       | 10.3.8  | 10.3.9  | [...](https://github.com/drupal/core-recommended/compare/10.3.8...10.3.9)       |
| unocha/common_design          | v9.4.3  | v9.4.4  | [...](https://github.com/UN-OCHA/common_design/compare/v9.4.3...v9.4.4)         |

