### PR TITLE
Deploy 21-03-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [9.8.1](https://github.com/UN-OCHA/gms-site/compare/v9.8.0...v9.8.1) (2025-03-20)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([f5b1b5](https://github.com/UN-OCHA/gms-site/commit/f5b1b55f4e6a7a6c3828cbcc0742882accd9cf3e))
+
 ## [9.8.0](https://github.com/UN-OCHA/gms-site/compare/v9.7.12...v9.8.0) (2025-03-17)
 
 ### Features

--- a/composer.json
+++ b/composer.json
@@ -309,5 +309,5 @@
             "@git-hooks"
         ]
     },
-    "version": "9.8.0"
+    "version": "9.8.1"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02c917b81d99549698b15f0095f16cbb",
+    "content-hash": "4afb6d4e3b587e052b9d4c19802e00fa",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [9.8.1](https://github.com/UN-OCHA/gms-site/compare/v9.8.0...v9.8.1) (2025-03-20)

### Chores

* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([f5b1b5](https://github.com/UN-OCHA/gms-site/commit/f5b1b55f4e6a7a6c3828cbcc0742882accd9cf3e))

## Composer changes

| Production Changes            | From    | To      | Compare                                                                         |
|-------------------------------|---------|---------|---------------------------------------------------------------------------------|
| aws/aws-sdk-php               | 3.342.4 | 3.342.9 | [...](https://github.com/aws/aws-sdk-php/compare/3.342.4...3.342.9)             |
| drupal/core                   | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core/compare/10.4.4...10.4.5)                   |
| drupal/core-composer-scaffold | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core-composer-scaffold/compare/10.4.4...10.4.5) |
| drupal/core-project-message   | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core-project-message/compare/10.4.4...10.4.5)   |
| drupal/core-recommended       | 10.4.4  | 10.4.5  | [...](https://github.com/drupal/core-recommended/compare/10.4.4...10.4.5)       |
| psy/psysh                     | v0.12.7 | v0.12.8 | [...](https://github.com/bobthecow/psysh/compare/v0.12.7...v0.12.8)             |
| unocha/ocha_monitoring        | 1.1.0   | 1.1.1   | [...](https://github.com/UN-OCHA/ocha_monitoring/compare/1.1.0...1.1.1)         |

