### PR TITLE
Deploy 16-04-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [9.8.2](https://github.com/UN-OCHA/gms-site/compare/v9.8.1...v9.8.2) (2025-04-15)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([dd63df](https://github.com/UN-OCHA/gms-site/commit/dd63df61d4a0dc44e124f13e603373536b6b78e3), [253d47](https://github.com/UN-OCHA/gms-site/commit/253d4719be329538f13cb9ea307e398981a05437), [0ac76f](https://github.com/UN-OCHA/gms-site/commit/0ac76f6277e0590a87fb29afe615d22bd8dc5fef))
+
 ## [9.8.1](https://github.com/UN-OCHA/gms-site/compare/v9.8.0...v9.8.1) (2025-03-20)
 
 ### Chores

--- a/composer.json
+++ b/composer.json
@@ -309,5 +309,5 @@
             "@git-hooks"
         ]
     },
-    "version": "9.8.1"
+    "version": "9.8.2"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4afb6d4e3b587e052b9d4c19802e00fa",
+    "content-hash": "d885554bbdc225adf47ac884eae28f54",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [9.8.2](https://github.com/UN-OCHA/gms-site/compare/v9.8.1...v9.8.2) (2025-04-15)

### Chores

* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([dd63df](https://github.com/UN-OCHA/gms-site/commit/dd63df61d4a0dc44e124f13e603373536b6b78e3), [253d47](https://github.com/UN-OCHA/gms-site/commit/253d4719be329538f13cb9ea307e398981a05437), [0ac76f](https://github.com/UN-OCHA/gms-site/commit/0ac76f6277e0590a87fb29afe615d22bd8dc5fef))

## Composer changes

| Production Changes            | From    | To       | Compare                                                                          |
|-------------------------------|---------|----------|----------------------------------------------------------------------------------|
| aws/aws-sdk-php               | 3.342.9 | 3.342.24 | [...](https://github.com/aws/aws-sdk-php/compare/3.342.9...3.342.24)             |
| doctrine/deprecations         | 1.1.4   | 1.1.5    | [...](https://github.com/doctrine/deprecations/compare/1.1.4...1.1.5)            |
| drupal/auto_config_form       | 1.1.0   | 1.1.1    | [...](https://git.drupalcode.org/project/auto_config_form/compare/1.1.0...1.1.1) |
| drupal/back_to_top            | 3.0.2   | 3.0.3    | [...](https://git.drupalcode.org/project/back_to_top/compare/3.0.2...3.0.3)      |
| drupal/core                   | 10.4.5  | 10.4.6   | [...](https://github.com/drupal/core/compare/10.4.5...10.4.6)                    |
| drupal/core-composer-scaffold | 10.4.5  | 10.4.6   | [...](https://github.com/drupal/core-composer-scaffold/compare/10.4.5...10.4.6)  |
| drupal/core-project-message   | 10.4.5  | 10.4.6   | [...](https://github.com/drupal/core-project-message/compare/10.4.5...10.4.6)    |
| drupal/core-recommended       | 10.4.5  | 10.4.6   | [...](https://github.com/drupal/core-recommended/compare/10.4.5...10.4.6)        |
| egulias/email-validator       | 4.0.3   | 4.0.4    | [...](https://github.com/egulias/EmailValidator/compare/4.0.3...4.0.4)           |
| guzzlehttp/guzzle             | 7.9.2   | 7.9.3    | [...](https://github.com/guzzle/guzzle/compare/7.9.2...7.9.3)                    |
| guzzlehttp/psr7               | 2.7.0   | 2.7.1    | [...](https://github.com/guzzle/psr7/compare/2.7.0...2.7.1)                      |
| symfony/console               | v6.4.17 | v6.4.20  | [...](https://github.com/symfony/console/compare/v6.4.17...v6.4.20)              |
| symfony/dependency-injection  | v6.4.19 | v6.4.20  | [...](https://github.com/symfony/dependency-injection/compare/v6.4.19...v6.4.20) |
| symfony/error-handler         | v6.4.19 | v6.4.20  | [...](https://github.com/symfony/error-handler/compare/v6.4.19...v6.4.20)        |
| symfony/http-kernel           | v6.4.19 | v6.4.20  | [...](https://github.com/symfony/http-kernel/compare/v6.4.19...v6.4.20)          |
| symfony/process               | v6.4.19 | v6.4.20  | [...](https://github.com/symfony/process/compare/v6.4.19...v6.4.20)              |
| symfony/validator             | v6.4.19 | v6.4.20  | [...](https://github.com/symfony/validator/compare/v6.4.19...v6.4.20)            |
| symfony/var-exporter          | v6.4.19 | v6.4.20  | [...](https://github.com/symfony/var-exporter/compare/v6.4.19...v6.4.20)         |
| symfony/yaml                  | v6.4.18 | v6.4.20  | [...](https://github.com/symfony/yaml/compare/v6.4.18...v6.4.20)                 |
| unocha/common_design          | v9.5.0  | v9.5.1   | [...](https://github.com/UN-OCHA/common_design/compare/v9.5.0...v9.5.1)          |
| unocha/ocha_monitoring        | 1.1.1   | 1.1.2    | [...](https://github.com/UN-OCHA/ocha_monitoring/compare/1.1.1...1.1.2)          |

