### PR TITLE
Deploy 06-05-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [9.8.3](https://github.com/UN-OCHA/gms-site/compare/v9.8.2...v9.8.3) (2025-05-05)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([40a553](https://github.com/UN-OCHA/gms-site/commit/40a553b332c67c909be1fe38205157b8dcd4d5ef), [fb55a2](https://github.com/UN-OCHA/gms-site/commit/fb55a2ac22b449f57690503bc6e371ae91b14255), [3db0f2](https://github.com/UN-OCHA/gms-site/commit/3db0f2797fe00575428558619c099ffd6bd8af5f))
+
 ## [9.8.2](https://github.com/UN-OCHA/gms-site/compare/v9.8.1...v9.8.2) (2025-04-15)
 
 ### Chores

--- a/composer.json
+++ b/composer.json
@@ -309,5 +309,5 @@
             "@git-hooks"
         ]
     },
-    "version": "9.8.2"
+    "version": "9.8.3"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d885554bbdc225adf47ac884eae28f54",
+    "content-hash": "3a9d89b964eb128338572f345dc63890",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [9.8.3](https://github.com/UN-OCHA/gms-site/compare/v9.8.2...v9.8.3) (2025-05-05)

### Chores

* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([40a553](https://github.com/UN-OCHA/gms-site/commit/40a553b332c67c909be1fe38205157b8dcd4d5ef), [fb55a2](https://github.com/UN-OCHA/gms-site/commit/fb55a2ac22b449f57690503bc6e371ae91b14255), [3db0f2](https://github.com/UN-OCHA/gms-site/commit/3db0f2797fe00575428558619c099ffd6bd8af5f))

## Composer changes

| Production Changes        | From     | To      | Compare                                                                          |
|---------------------------|----------|---------|----------------------------------------------------------------------------------|
| aws/aws-sdk-php           | 3.342.24 | 3.343.1 | [...](https://github.com/aws/aws-sdk-php/compare/3.342.24...3.343.1)             |
| drupal/block_class        | 4.0.0    | 4.0.1   | [...](https://git.drupalcode.org/project/block_class/compare/4.0.0...4.0.1)      |
| drupal/genpass            | 2.1.1    | 2.1.2   | [...](https://git.drupalcode.org/project/genpass/compare/2.1.1...2.1.2)          |
| drupal/stage_file_proxy   | 3.1.4    | 3.1.5   | [...](https://git.drupalcode.org/project/stage_file_proxy/compare/3.1.4...3.1.5) |
| drupal/superfish          | 1.10.0   | 1.11.0  | [...](https://git.drupalcode.org/project/superfish/compare/1.10.0...1.11.0)      |
| lobsterr/drupal-superfish | 2.3.2    | 2.3.8   | [...](https://github.com/LOBsTerr/drupal-superfish/compare/2.3.2...2.3.8)        |

