### PR TITLE
fix: restore the admin theme for the stories entity browser (removed in entity_browser 2.17) to avoid potential errors caused by the front-end theme.

### DIFF
--- a/config/entity_browser.browser.media_entity_browser.yml
+++ b/config/entity_browser.browser.media_entity_browser.yml
@@ -18,6 +18,7 @@ display_configuration:
   link_text: 'Select media'
   auto_open: true
   path: ''
+  use_admin_theme: true
 selection_display: no_display
 selection_display_configuration:
   view: null

--- a/config/entity_browser.browser.media_entity_browser_media_library.yml
+++ b/config/entity_browser.browser.media_entity_browser_media_library.yml
@@ -17,6 +17,7 @@ display_configuration:
   height: '500'
   link_text: 'Select media'
   auto_open: true
+  use_admin_theme: true
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: tabs

--- a/config/entity_browser.browser.media_entity_browser_modal.yml
+++ b/config/entity_browser.browser.media_entity_browser_modal.yml
@@ -17,6 +17,7 @@ display_configuration:
   height: '500'
   link_text: 'Select media'
   auto_open: true
+  use_admin_theme: true
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: tabs

--- a/config/entity_browser.browser.test_files.yml
+++ b/config/entity_browser.browser.test_files.yml
@@ -19,6 +19,7 @@ display_configuration:
   height: '500'
   link_text: 'Select entities'
   auto_open: false
+  use_admin_theme: true
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: tabs

--- a/config/entity_browser.browser.test_files1.yml
+++ b/config/entity_browser.browser.test_files1.yml
@@ -15,6 +15,7 @@ display_configuration:
   height: '500'
   link_text: 'Select entities'
   auto_open: false
+  use_admin_theme: true
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: single

--- a/config/entity_browser.browser.test_files_ajax.yml
+++ b/config/entity_browser.browser.test_files_ajax.yml
@@ -19,6 +19,7 @@ display_configuration:
   height: '500'
   link_text: 'Select entities'
   auto_open: false
+  use_admin_theme: true
 selection_display: multi_step_display
 selection_display_configuration:
   entity_type: node

--- a/config/entity_browser.browser.test_nodes.yml
+++ b/config/entity_browser.browser.test_nodes.yml
@@ -19,6 +19,7 @@ display_configuration:
   height: '500'
   link_text: 'Select entities'
   auto_open: false
+  use_admin_theme: true
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: single


### PR DESCRIPTION
The entity_browser module introduced a new user_admin_theme setting in 2.17 with a bad default (unchecked). Before the entity browsers were always using the admin theme.

This caused the entity browser to use common design theme which resulted in a 500 (not sure why but maybe because some preprocess hooks clashed with the ajax processed form).

This simply set the new setting to true.

Refs: UNO-908